### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfyui-magickwand"
-description = ""
+description = "Proper implementation of ImageMagick - the famous software suite for editing and manipulating digital images to ComfyUI using [wandpy](https://github.com/emcconville/wand)"
 version = "1.0.0"
 license = "LICENSE"
 dependencies = ["Wand"]
@@ -9,7 +9,7 @@ dependencies = ["Wand"]
 Repository = "https://github.com/Fannovel16/ComfyUI-MagickWand"
 
 [tool.comfy]
-PublisherId = ""
+PublisherId = "fannovel16"
 DisplayName = "ComfyUI-MagickWand"
 Icon = ""
 Models = [{location = "/checkpoints/model.safetensor", model_url = "https://example.com/model.zip"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui-magickwand"
+description = ""
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["Wand"]
+
+[project.urls]
+Repository = "https://github.com/Fannovel16/ComfyUI-MagickWand"
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-MagickWand"
+Icon = ""
+Models = [{location = "/checkpoints/model.safetensor", model_url = "https://example.com/model.zip"}]


### PR DESCRIPTION
We are building a global registry for custom nodes (similar to PyPI). The registry makes using custom nodes more reliable by reserving globally unique names for each custom node, and supporting semantic versioning.

Here’s some [more information](https://comfydocs.org/registry/overview#introduction) on the registry.

Action Required:

- [ ] Go to the [registry](https://comfyregistry.org/). Login and create a publisher id. Comment it here and we will update the PR (or just merge it and change it yourself).
- [ ] Write a short the description.
- [ ] Merge the separate Github Actions PR and run the workflow.

If you want to publish the node manually, [install the cli](https://comfydocs.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`
Please message me on [Discord](https://discord.com/invite/comfyorg) if you have any questions!